### PR TITLE
Add support for managing the SOA record

### DIFF
--- a/docs/data-sources/record.md
+++ b/docs/data-sources/record.md
@@ -32,6 +32,7 @@ Below are the supported resource record types with the corresponding number:<br/
 `A (1)`
 `NS (2)`
 `CNAME (5)`
+`SOA (6)`
 `PTR (12)`
 `MX (15)`
 `TXT (16)`

--- a/docs/resources/record.md
+++ b/docs/resources/record.md
@@ -48,6 +48,18 @@ resource "ultradns_record" "cname" {
 }
 ```
 
+### Create DNS record of type SOA (6)
+
+```terraform
+resource "ultradns_record" "soa" {
+    zone_name = "example.com."
+    owner_name = "example.com."
+    record_type = "SOA"
+    ttl = 112600
+    record_data = ["ns11.example.com primary_domain 1111111111 86400 7200 4000000 112600"]
+}
+```
+
 ### Create DNS record of type PTR (12)
 
 ```terraform
@@ -143,6 +155,7 @@ Below are the supported resource record types with the corresponding number:<br/
 `A (1)`
 `NS (2)`
 `CNAME (5)`
+`SOA (6)`
 `PTR (12)`
 `MX (15)`
 `TXT (16)`

--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -60,6 +60,7 @@ func RecordTypeValidation(i interface{}, p cty.Path) diag.Diagnostics {
 		"A": true, "1": true,
 		"NS": true, "2": true,
 		"CNAME": true, "5": true,
+		"SOA": true, "6": true,
 		"PTR": true, "12": true,
 		"MX": true, "15": true,
 		"TXT": true, "16": true,

--- a/internal/record/data_source_record_test.go
+++ b/internal/record/data_source_record_test.go
@@ -157,6 +157,24 @@ func TestAccDataSourceRecord(t *testing.T) {
 			{
 				Config: acctest.TestAccDataSourceRRSet(
 					"ultradns_record",
+					"srv",
+					zoneName,
+					tfacctest.RandString(3),
+					"SOA",
+					testAccResourceRecordSRV(zoneName),
+				),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.TestAccCheckRecordResourceExists("data.ultradns_record.data_srv", ""),
+					resource.TestCheckResourceAttr("data.ultradns_record.data_srv", "zone_name", zoneName),
+					resource.TestCheckResourceAttr("data.ultradns_record.data_srv", "record_type", "SRV"),
+					resource.TestCheckResourceAttr("data.ultradns_record.data_srv", "ttl", "112600"),
+					resource.TestCheckResourceAttr("data.ultradns_record.data_srv", "record_data.0", "ns11.example.com primary_domain 1111111111 86400 7200 4000000 112600"),
+				),
+			},
+
+			{
+				Config: acctest.TestAccDataSourceRRSet(
+					"ultradns_record",
 					"sshfp",
 					zoneName,
 					tfacctest.RandString(3),

--- a/internal/record/resource_record_test.go
+++ b/internal/record/resource_record_test.go
@@ -168,6 +168,21 @@ func TestAccResourceRecord(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
+				Config: testAccResourceRecordSOA(zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.TestAccCheckRecordResourceExists("ultradns_record.srv", ""),
+					resource.TestCheckResourceAttr("ultradns_record.srv", "zone_name", zoneName),
+					resource.TestCheckResourceAttr("ultradns_record.srv", "record_type", "SOA"),
+					resource.TestCheckResourceAttr("ultradns_record.srv", "ttl", "112600"),
+					resource.TestCheckResourceAttr("ultradns_record.srv", "record_data.0", "ns11.example.com primary_domain 1111111111 86400 7200 4000000 112600"),
+				),
+			},
+			{
+				ResourceName:      "ultradns_record.srv",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccResourceRecordSSHFP(zoneName),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.TestAccCheckRecordResourceExists("ultradns_record.sshfp", ""),
@@ -347,6 +362,20 @@ func testAccResourceRecordSRV(zoneName string) string {
 		record_type = "SRV"
 		ttl = 800
 		record_data = ["5 6 7 example.com."]
+	}
+	`, acctest.TestAccResourceZonePrimary(zoneResourceName, zoneName), tfacctest.RandString(3))
+}
+
+func testAccResourceRecordSOA(zoneName string) string {
+	return fmt.Sprintf(`
+	%s
+
+	resource "ultradns_record" "soa" {
+		zone_name = "${resource.ultradns_zone.primary_record.id}"
+		owner_name = "%s.${resource.ultradns_zone.primary_record.id}"
+		record_type = "SOA"
+		ttl = 112600
+		record_data = ["ns11.example.com primary_domain 1111111111 86400 7200 4000000 112600"]
 	}
 	`, acctest.TestAccResourceZonePrimary(zoneResourceName, zoneName), tfacctest.RandString(3))
 }


### PR DESCRIPTION
Adds support for managing the SOA record.

As the API does not support creation / deletion of SOA records, this is accomplished by:
 - Using the Update API method when creating the resource.
   - UltraDNS creates the SOA automatically when the domain is created, so we assume it exists.
 - Doing nothing on calls to delete the resource
   - This is similar to the way the `google` provider works with root NS Records:
   - https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/third_party/terraform/resources/resource_dns_record_set.go#L470